### PR TITLE
added -h option with 0 exit code

### DIFF
--- a/format-udf.sh
+++ b/format-udf.sh
@@ -279,7 +279,7 @@ WIPE_METHOD=quick
 
 echo "[+] Parsing options..."
 
-while getopts ":b:fp:w:" opt; do
+while getopts ":b:fp:w:h" opt; do
     case $opt in
         b)
             ARG_BLOCK_SIZE="$OPTARG"
@@ -312,6 +312,10 @@ while getopts ":b:fp:w:" opt; do
                     exit 1
                 fi
             fi
+            ;;
+        h)
+            print_usage
+            exit 0
             ;;
         \?)
             echo "[-] Invalid option '-$OPTARG'" >&2


### PR DESCRIPTION
Using `./format-udf.sh -h` will print the usage info with exit 0
This will allow me to add this script to Homebrew, as the test block requires a 0 exit code
Unless the script is run fully (which cannot be done with a disk image), there is no way to make a test block that passes in Ruby