### PR TITLE
add linux nvme support

### DIFF
--- a/format-udf.sh
+++ b/format-udf.sh
@@ -306,7 +306,7 @@ DEVICE=$1
 LABEL=$2
 
 # validate device identifier (may be partition)
-(echo "$DEVICE" | grep -Eq '^(([hs]d[a-z])([1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$') || (echo "[-] <device> is of invalid form" >&2; false)
+(echo "$DEVICE" | grep -Eq '^(([hs]d[a-z])([1-9][0-9]*)?|(nvme[0-9]+n1)(p[1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$') || (echo "[-] <device> is of invalid form" >&2; false)
 
 # verify this is a device, not just a file
 # `true` is so that a failure here doesn't cause entire script to exit prematurely
@@ -324,14 +324,14 @@ trap exit_with_no_changes EXIT
 # extract parent device identifier
 if sed --version &> /dev/null; then
     # this box has GNU sed ('-r' for extended regex)
-    PARENT_DEVICE=$(echo "$DEVICE" | sed -r 's/^(([hs]d[a-z])([1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$/\2\4\6/')
+    PARENT_DEVICE=$(echo "$DEVICE" | sed -r 's/^(([hs]d[a-z])([1-9][0-9]*)?|(nvme[0-9]+n1)(p[1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$/\2\4\6/')
 else
     # this machine must have BSD sed ('-E' for extended regex)
-    PARENT_DEVICE=$(echo "$DEVICE" | sed -E 's/^(([hs]d[a-z])([1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$/\2\4\6/')
+    PARENT_DEVICE=$(echo "$DEVICE" | sed -E 's/^(([hs]d[a-z])([1-9][0-9]*)?|(nvme[0-9]+n1)(p[1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$/\2\4\6/')
 fi
 
 # validate parent device identifier (must be entire device)
-(echo "$PARENT_DEVICE" | grep -Eq '^([hs]d[a-z]|disk[0-9]+|loop[0-9]+)$') || (echo "[-] <device> is of invalid form (invalid parent device)" >&2; false)
+(echo "$PARENT_DEVICE" | grep -Eq '^([hs]d[a-z]|nvme[0-9]+n1|disk[0-9]+|loop[0-9]+)$') || (echo "[-] <device> is of invalid form (invalid parent device)" >&2; false)
 
 # verify parent is a device, not just a file
 [[ -b /dev/$PARENT_DEVICE ]] || (echo "[-] /dev/$PARENT_DEVICE either doesn't exist or is not block special" >&2; false)


### PR DESCRIPTION
Tested correctly under Ubuntu 18.04.3 amd64 with Intel p660 2TB nvme 512KB SSD. Multiple nvme existed in the same system and the first one was correctly identified and formated by your modified UDF script "/dev/nvme0n1" the second one was correctly unaffected "/dev/nvme1n1". Disk was read/writable both by Ubuntu 18.04.3 and by Windows 10 1907.

Partitions on nvme "/dev/nvme0n1p1" are identified using an aditional 'p' similar to MacOS using 's' and gives correct handling of the script by suggesting you'd better not use partions(haven't tested a partitioning since its incompatible with MacOS). Also giving a non existing nvme3n1 as device argument gets detected as not valid. 

Note about nvme, the device exists as /dev/nvme0 but its writable block device is /dev/nvme0n1 and its first partition is /dev/nvme0n1p1.