### PR TITLE
add linux mmcblk0 sdcard support fixes #46

### DIFF
--- a/format-udf.sh
+++ b/format-udf.sh
@@ -306,7 +306,7 @@ DEVICE=$1
 LABEL=$2
 
 # validate device identifier (may be partition)
-(echo "$DEVICE" | grep -Eq '^(([hs]d[a-z])([1-9][0-9]*)?|(nvme[0-9]+n1)(p[1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$') || (echo "[-] <device> is of invalid form" >&2; false)
+(echo "$DEVICE" | grep -Eq '^(([hs]d[a-z])([1-9][0-9]*)?|(nvme[0-9]+n1)(p[1-9][0-9]*)?|(mmcblk[0-9]+)(p[1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$') || (echo "[-] <device> is of invalid form" >&2; false)
 
 # verify this is a device, not just a file
 # `true` is so that a failure here doesn't cause entire script to exit prematurely
@@ -324,14 +324,14 @@ trap exit_with_no_changes EXIT
 # extract parent device identifier
 if sed --version &> /dev/null; then
     # this box has GNU sed ('-r' for extended regex)
-    PARENT_DEVICE=$(echo "$DEVICE" | sed -r 's/^(([hs]d[a-z])([1-9][0-9]*)?|(nvme[0-9]+n1)(p[1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$/\2\4\6\8/')
+    PARENT_DEVICE=$(echo "$DEVICE" | sed -r 's/^(([hs]d[a-z])([1-9][0-9]*)?|(nvme[0-9]+n1)(p[1-9][0-9]*)?|(mmcblk[0-9]+)(p[1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$/\2\4\6\8/')
 else
     # this machine must have BSD sed ('-E' for extended regex)
-    PARENT_DEVICE=$(echo "$DEVICE" | sed -E 's/^(([hs]d[a-z])([1-9][0-9]*)?|(nvme[0-9]+n1)(p[1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$/\2\4\6\8/')
+    PARENT_DEVICE=$(echo "$DEVICE" | sed -E 's/^(([hs]d[a-z])([1-9][0-9]*)?|(nvme[0-9]+n1)(p[1-9][0-9]*)?|(mmcblk[0-9]+)(p[1-9][0-9]*)?|(disk[0-9]+)(s[1-9][0-9]*)?|(loop[0-9]+))$/\2\4\6\8/')
 fi
 
 # validate parent device identifier (must be entire device)
-(echo "$PARENT_DEVICE" | grep -Eq '^([hs]d[a-z]|nvme[0-9]+n1|disk[0-9]+|loop[0-9]+)$') || (echo "[-] <device> is of invalid form (invalid parent device)" >&2; false)
+(echo "$PARENT_DEVICE" | grep -Eq '^([hs]d[a-z]|nvme[0-9]+n1|mmcblk[0-9]+|disk[0-9]+|loop[0-9]+)$') || (echo "[-] <device> is of invalid form (invalid parent device)" >&2; false)
 
 # verify parent is a device, not just a file
 [[ -b /dev/$PARENT_DEVICE ]] || (echo "[-] /dev/$PARENT_DEVICE either doesn't exist or is not block special" >&2; false)


### PR DESCRIPTION
Some SDcard readers identify the SDcard block device with /dev/mmcblk0 or /dev/mmcblk1 instead of  /dev/sdX used by regular USB storage devices. Partitions on these blockdevices are identified with an aditional 'p' like the nvme. 

This fixes #46 , however I cannot verify mmcblk1 since I only have 1 device.