### PR TITLE
allow '/dev/' prefix for <device> argument fix #25

### DIFF
--- a/format-udf.sh
+++ b/format-udf.sh
@@ -301,8 +301,8 @@ if [[ $# -ne 2 ]]; then
     exit 1
 fi
 
-# setup variables for arguments
-DEVICE=$1
+# setup variables for arguments and remove '/dev/' prefix when used
+DEVICE=$(echo $1 | sed -e 's|/dev/||')
 LABEL=$2
 
 # validate device identifier (may be partition)


### PR DESCRIPTION
Verified on MacOS Yosemite 10.10.5 and Ubuntu 19.10 both tested with and without '/dev/' prefix. This fixes #25 .